### PR TITLE
Fix deprecated warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.4",
+    "prop-types": "^15.6.0",
     "react": "^15.4.2"
   }
 }

--- a/src/ErrorMessages.js
+++ b/src/ErrorMessages.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import templateFn from 'lodash/template';
 
 const errors = {
@@ -63,9 +64,9 @@ export class ErrorMessage extends React.Component {
   }
 }
 ErrorMessage.propTypes = {
-  when: React.PropTypes.string.isRequired,
-  children: React.PropTypes.string.isRequired,
-  params: React.PropTypes.any, // eslint-disable-line
+  when: PropTypes.string.isRequired,
+  children: PropTypes.string.isRequired,
+  params: PropTypes.any, // eslint-disable-line
 };
 
 export const ErrorMessagesComponent = ({ error, children }) => {


### PR DESCRIPTION
`
Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
`

Tested on React 15.6.2